### PR TITLE
treewide: s/stdenv/stdenvNoCC/g

### DIFF
--- a/packages/paper/default.nix
+++ b/packages/paper/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, bash, jre, version, build, url, sha256 }:
+{ lib, stdenvNoCC, fetchurl, bash, jre, version, build, url, sha256 }:
 let
   jar = fetchurl { inherit url sha256; };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "papermc";
   version = "${version}-${toString build}";
 

--- a/packages/purpur/default.nix
+++ b/packages/purpur/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, nixosTests, jre_headless, version, build, url, sha256 }:
-stdenv.mkDerivation {
+{ lib, stdenvNoCC, fetchurl, nixosTests, jre_headless, version, build, url, sha256 }:
+stdenvNoCC.mkDerivation {
   pname = "purpur";
   version = "${version}-${toString build}";
 

--- a/packages/vanilla/default.nix
+++ b/packages/vanilla/default.nix
@@ -1,10 +1,10 @@
-{ lib, stdenv, fetchurl, nixosTests, javaPackages, version, url, sha1, javaVersion }:
+{ lib, stdenvNoCC, fetchurl, nixosTests, javaPackages, version, url, sha1, javaVersion }:
 let
   getJavaVersion = v: (builtins.getAttr "openjdk${toString v}" javaPackages.compiler).headless;
   # versions <= 1.6 will default to 8
   jre_headless = getJavaVersion (if javaVersion == null then 8 else javaVersion);
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "minecraft-server";
   inherit version;
 

--- a/packages/velocity/default.nix
+++ b/packages/velocity/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, bash, jre, version, build, url, sha256 }:
+{ lib, stdenvNoCC, fetchurl, bash, jre, version, build, url, sha256 }:
 let
   jar = fetchurl { inherit url sha256; };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "velocity";
   version = "${version}-${toString build}";
 

--- a/packages/waterfall/default.nix
+++ b/packages/waterfall/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, bash, jre, version, build, url, sha256 }:
+{ lib, stdenvNoCC, fetchurl, bash, jre, version, build, url, sha256 }:
 let
   jar = fetchurl { inherit url sha256; };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "waterfall";
   version = "${version}-${toString build}";
 


### PR DESCRIPTION
Saves some time downloading GCC and stuff on a clean build.